### PR TITLE
fix: harden IPv6 SSRF protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The code protected against SSRF by checking for known private IPs. However, it used simple `startsWith` checks for IPv6 (e.g. `ip.startsWith('fc00:')`) which fails to block all valid private ranges (e.g., `fd00:` is also ULA, and `fc...` can be written in many compressed/uncompressed formats). Furthermore, IPv4-mapped IPv6 addresses (e.g., `::ffff:127.0.0.1`) could bypass the loopback check if not exact matched.
 **Learning:** Checking IPv6 representations via strings is dangerous and flawed due to multiple valid representations (zero compression, leading zero dropping, uppercase/lowercase, and v4 mapped formats).
 **Prevention:** Normalize IPv6 addresses securely before validation. Node.js `URL` object can normalize them (`new URL('http://[' + ip + ']').hostname`). And always map IPv4-mapped IPv6 formats back to their IPv4 equivalents before applying blacklist logic.
+
+## 2024-05-24 - Conventional Commits in PR Titles
+**Vulnerability:** CI fails on PR creation if the title doesn't follow Conventional Commits formatting.
+**Learning:** The `amannn/action-semantic-pull-request` action strictly enforces Conventional Commit prefixes (`fix:`, `feat:`, etc.). My persona formatting (`🛡️ Sentinel: ...`) caused validation to fail.
+**Prevention:** Always prefix PR titles with a Conventional Commit type (e.g., `fix: 🛡️ Sentinel: ...`).

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** CI fails on PR creation if the title doesn't follow Conventional Commits formatting.
 **Learning:** The `amannn/action-semantic-pull-request` action strictly enforces Conventional Commit prefixes (`fix:`, `feat:`, etc.). My persona formatting (`🛡️ Sentinel: ...`) caused validation to fail.
 **Prevention:** Always prefix PR titles with a Conventional Commit type (e.g., `fix: 🛡️ Sentinel: ...`).
+
+## 2024-05-24 - Semantic Pull Request Checks
+**Vulnerability:** Pull requests fail in CI if they lack a valid Semantic Pull Request prefix.
+**Learning:** Even when applying persona formatting like `🛡️ Sentinel: `, the pull request title *must* start with a valid semantic prefix (like `fix:`, `feat:`, `chore:`), otherwise actions like `amannn/action-semantic-pull-request` will fail.
+**Prevention:** Construct PR titles like `fix: 🛡️ Sentinel: [Critical] Fix incomplete SSRF Protection in IPv6 Address Validation`.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,18 @@
 **Vulnerability:** Potential Regular Expression Denial of Service (ReDoS) vulnerability due to unbounded execution of a complex SemVer regex in `src/metadata.ts`.
 **Learning:** Even well-established and standard regex patterns (like the official SemVer regex) can consume excessive CPU resources when executed on overly long strings. Unbounded input length is a common vector for ReDoS.
 **Prevention:** Always bound input lengths (e.g., `if (version.length > 256) return false`) before executing complex regular expressions on externally provided data.
+
+## 2024-03-16 - SSRF Protection via URL Validation
+**Vulnerability:** The action fetches URLs from metadata.rb (source_url, issues_url) using `undici.request` without validating the URL scheme or hostname. This creates a potential Server-Side Request Forgery (SSRF) risk, allowing arbitrary file reading via `file://` or fetching cloud metadata/internal endpoints via `http://`.
+**Learning:** External inputs like URLs from metadata files must be validated for allowed protocols (HTTP/HTTPS) and protected against targeting internal metadata services (e.g., 169.254.169.254), particularly in GitHub Actions which run in cloud environments.
+**Prevention:** Implement a rigorous URL validation check before passing strings to the `request` function. Check both the protocol/scheme and block known cloud metadata IPs and localhost addresses.
+
+## 2024-03-16 - SSRF Bypass via DNS Rebinding and Alternate IP Encoding
+**Vulnerability:** Even though string-based filtering was implemented to block common loopback (localhost) and internal IP addresses, alternate encodings (e.g. decimal `0x7f000001` or octal) or public DNS names mapping to local IPs (e.g., `localtest.me` pointing to `127.0.0.1`) bypassed these checks.
+**Learning:** Checking a hostname string against a hardcoded blocklist is insufficient for SSRF protection because attackers can construct various domain strings that ultimately resolve to forbidden IP ranges. A malicious domain can also use DNS Rebinding to switch resolution from a benign IP to a private IP after validation.
+**Prevention:** Always use tools like `dns.promises.lookup()` to first resolve any hostname or IP literal to a concrete IP address before performing validation. Validate the underlying resolved IP against disallowed loopback (127.x.x.x), link-local (169.254.x.x), or private network ranges (10.x.x.x, 172.16-31.x.x, 192.168.x.x) rather than matching the raw input string.
+
+## 2024-05-24 - SSRF Bypass via Incomplete IPv6 Checks
+**Vulnerability:** The code protected against SSRF by checking for known private IPs. However, it used simple `startsWith` checks for IPv6 (e.g. `ip.startsWith('fc00:')`) which fails to block all valid private ranges (e.g., `fd00:` is also ULA, and `fc...` can be written in many compressed/uncompressed formats). Furthermore, IPv4-mapped IPv6 addresses (e.g., `::ffff:127.0.0.1`) could bypass the loopback check if not exact matched.
+**Learning:** Checking IPv6 representations via strings is dangerous and flawed due to multiple valid representations (zero compression, leading zero dropping, uppercase/lowercase, and v4 mapped formats).
+**Prevention:** Normalize IPv6 addresses securely before validation. Node.js `URL` object can normalize them (`new URL('http://[' + ip + ']').hostname`). And always map IPv4-mapped IPv6 formats back to their IPv4 equivalents before applying blacklist logic.

--- a/dist/index.js
+++ b/dist/index.js
@@ -74832,6 +74832,38 @@ async function isUrlAccessible(url, timeout = URL_ACCESSIBILITY_TIMEOUT_MS) {
   if (cached !== void 0) {
     return cached;
   }
+  const isPrivateIp = (ipAddress) => {
+    if (ipAddress === "0.0.0.0" || ipAddress === "255.255.255.255") return true;
+    if (net.isIPv4(ipAddress)) {
+      const parts = ipAddress.split(".").map(Number);
+      return parts[0] === 127 || // Loopback
+      parts[0] === 10 || // Private
+      parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31 || // Private
+      parts[0] === 192 && parts[1] === 168 || // Private
+      parts[0] === 169 && parts[1] === 254 || // Link-local
+      parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127;
+    } else if (net.isIPv6(ipAddress)) {
+      const ip = new URL(`http://[${ipAddress}]`).hostname.replace(/[[\]]/g, "").toLowerCase();
+      if (ip === "::1" || ip === "::") return true;
+      if (/^f[cd][0-9a-f]{2}:/.test(ip)) return true;
+      if (/^fe[89ab][0-9a-f]:/.test(ip)) return true;
+      if (ip.startsWith("::ffff:")) {
+        const ipv4Match = /^::ffff:(?:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|([0-9a-f]{1,4}):([0-9a-f]{1,4}))$/.exec(
+          ip
+        );
+        if (ipv4Match) {
+          let ipv4 = ipv4Match[1];
+          if (!ipv4) {
+            const p1 = parseInt(ipv4Match[2], 16);
+            const p2 = parseInt(ipv4Match[3], 16);
+            ipv4 = `${p1 >> 8}.${p1 & 255}.${p2 >> 8}.${p2 & 255}`;
+          }
+          return isPrivateIp(ipv4);
+        }
+      }
+    }
+    return false;
+  };
   const checkPromise = (async () => {
     try {
       const parsedUrl = new URL(url);
@@ -74846,27 +74878,8 @@ async function isUrlAccessible(url, timeout = URL_ACCESSIBILITY_TIMEOUT_MS) {
       } catch {
         return false;
       }
-      if (ipAddress === "0.0.0.0" || ipAddress === "255.255.255.255") {
+      if (isPrivateIp(ipAddress)) {
         return false;
-      }
-      if (net.isIPv4(ipAddress)) {
-        const parts = ipAddress.split(".").map(Number);
-        if (parts[0] === 127 || // Loopback (127.0.0.0/8)
-        parts[0] === 10 || // Private (10.0.0.0/8)
-        parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31 || // Private (172.16.0.0/12)
-        parts[0] === 192 && parts[1] === 168 || // Private (192.168.0.0/16)
-        parts[0] === 169 && parts[1] === 254 || // Link-local (169.254.0.0/16)
-        parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) {
-          return false;
-        }
-      } else if (net.isIPv6(ipAddress)) {
-        const ip = ipAddress.toLowerCase();
-        if (ip === "::1" || // Loopback
-        ip.startsWith("::ffff:127.") || // IPv4-mapped IPv6 loopback
-        ip.startsWith("fc00:") || ip.startsWith("fd00:") || // Unique local address (ULA)
-        ip.startsWith("fe80:")) {
-          return false;
-        }
       }
       const safeUrl = new URL(url);
       safeUrl.hostname = ipAddress;

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -246,6 +246,45 @@ export async function isUrlAccessible(
     return cached
   }
 
+  const isPrivateIp = (ipAddress: string): boolean => {
+    if (ipAddress === '0.0.0.0' || ipAddress === '255.255.255.255') return true
+    if (net.isIPv4(ipAddress)) {
+      const parts = ipAddress.split('.').map(Number)
+      return (
+        parts[0] === 127 || // Loopback
+        parts[0] === 10 || // Private
+        (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) || // Private
+        (parts[0] === 192 && parts[1] === 168) || // Private
+        (parts[0] === 169 && parts[1] === 254) || // Link-local
+        (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) // Carrier-grade NAT
+      )
+    } else if (net.isIPv6(ipAddress)) {
+      const ip = new URL(`http://[${ipAddress}]`).hostname
+        .replace(/[[\]]/g, '')
+        .toLowerCase()
+      if (ip === '::1' || ip === '::') return true // Loopback / Unspecified
+      if (/^f[cd][0-9a-f]{2}:/.test(ip)) return true // Unique local address (ULA)
+      if (/^fe[89ab][0-9a-f]:/.test(ip)) return true // Link-local
+      if (ip.startsWith('::ffff:')) {
+        // IPv4-mapped IPv6
+        const ipv4Match =
+          /^::ffff:(?:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|([0-9a-f]{1,4}):([0-9a-f]{1,4}))$/.exec(
+            ip
+          )
+        if (ipv4Match) {
+          let ipv4 = ipv4Match[1]
+          if (!ipv4) {
+            const p1 = parseInt(ipv4Match[2], 16)
+            const p2 = parseInt(ipv4Match[3], 16)
+            ipv4 = `${p1 >> 8}.${p1 & 0xff}.${p2 >> 8}.${p2 & 0xff}`
+          }
+          return isPrivateIp(ipv4)
+        }
+      }
+    }
+    return false
+  }
+
   const checkPromise = (async () => {
     try {
       const parsedUrl = new URL(url)
@@ -269,33 +308,8 @@ export async function isUrlAccessible(
         return false // DNS resolution failed
       }
 
-      if (ipAddress === '0.0.0.0' || ipAddress === '255.255.255.255') {
+      if (isPrivateIp(ipAddress)) {
         return false
-      }
-
-      if (net.isIPv4(ipAddress)) {
-        const parts = ipAddress.split('.').map(Number)
-        if (
-          parts[0] === 127 || // Loopback (127.0.0.0/8)
-          parts[0] === 10 || // Private (10.0.0.0/8)
-          (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) || // Private (172.16.0.0/12)
-          (parts[0] === 192 && parts[1] === 168) || // Private (192.168.0.0/16)
-          (parts[0] === 169 && parts[1] === 254) || // Link-local (169.254.0.0/16)
-          (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) // Carrier-grade NAT (100.64.0.0/10)
-        ) {
-          return false
-        }
-      } else if (net.isIPv6(ipAddress)) {
-        const ip = ipAddress.toLowerCase()
-        if (
-          ip === '::1' || // Loopback
-          ip.startsWith('::ffff:127.') || // IPv4-mapped IPv6 loopback
-          ip.startsWith('fc00:') ||
-          ip.startsWith('fd00:') || // Unique local address (ULA)
-          ip.startsWith('fe80:') // Link-local
-        ) {
-          return false
-        }
       }
 
       // SSRF Protection: Prevent DNS rebinding by sending request directly to the validated IP


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Incomplete SSRF protection due to flawed IPv6 validation. The previous logic used simple `startsWith` checks on raw IPv6 representations. This failed to account for multiple valid representations of identical addresses (e.g., zero compression, leading zero dropping) and failed to securely block all ULA, Link-Local, and IPv4-mapped IPv6 address formats.

⚠️ **Risk:** The potential impact if left unfixed
High/Critical. An attacker could bypass the SSRF blacklisting by providing alternative IPv6 formats for private/loopback addresses (e.g., `[0000:0000:0000:0000:0000:ffff:127.0.0.1]`), or by exploiting unblocked ULA blocks (like `fd00::/8`). This could allow unauthorized requests to internal cloud metadata instances or internal local network endpoints.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix implements an explicit `isPrivateIp` validation function:
1. **Normalization**: Uses `new URL('http://[' + ipAddress + ']')` to reliably canonicalize IPv6 representations utilizing Node's built-in parser without adding external dependencies.
2. **Robust Pattern Matching**: Properly matches loopback, ULA, and Link-Local spaces.
3. **IPv4-Mapped Re-Validation**: Extracts the mapped IPv4 representation from `::ffff:...` and correctly passes it recursively back through the complete IPv4 validation logic (including checking 127/8, 10/8, 172.16/12, etc.).

---
*PR created automatically by Jules for task [7626082924824090924](https://jules.google.com/task/7626082924824090924) started by @damacus*