### PR TITLE
fix: retry URL accessibility checks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -47831,8 +47831,8 @@ var require_socks5_client = __commonJS({
           return;
         }
         if (reply !== REPLY_CODES.SUCCEEDED) {
-          const errorMessage = this.getReplyErrorMessage(reply);
-          throw new Socks5ProxyError(`SOCKS5 connection failed: ${errorMessage}`, `UND_ERR_SOCKS5_REPLY_${reply}`);
+          const errorMessage2 = this.getReplyErrorMessage(reply);
+          throw new Socks5ProxyError(`SOCKS5 connection failed: ${errorMessage2}`, `UND_ERR_SOCKS5_REPLY_${reply}`);
         }
         let boundAddress;
         let offset = 4;
@@ -67017,6 +67017,9 @@ function setFailed(message) {
   process.exitCode = ExitCode.Failure;
   error(message);
 }
+function debug(message) {
+  issueCommand("debug", {}, message);
+}
 function error(message, properties = {}) {
   issueCommand("error", toCommandProperties(properties), message instanceof Error ? message.toString() : message);
 }
@@ -73834,7 +73837,31 @@ var isValidDepends = (depends) => {
   return !!cookbook;
 };
 var urlAccessibilityCache = /* @__PURE__ */ new Map();
-async function isUrlAccessible(url, timeout = 5e3) {
+var URL_ACCESSIBILITY_TIMEOUT_MS = 15e3;
+var URL_ACCESSIBILITY_ATTEMPTS = 3;
+var URL_ACCESSIBILITY_BODY_DUMP_LIMIT_BYTES = 1024 * 1024;
+var TRANSIENT_HTTP_STATUSES = /* @__PURE__ */ new Set([408, 429, 500, 502, 503, 504]);
+var sleep = async (ms2) => new Promise((resolve) => setTimeout(resolve, ms2));
+var errorMessage = (error2) => {
+  if (error2 instanceof Error) {
+    const maybeCode = error2.code;
+    return maybeCode ? `${maybeCode}: ${error2.message}` : error2.message;
+  }
+  return String(error2);
+};
+var drainResponseBody = async (url, body) => {
+  if (typeof body.dump !== "function") {
+    return;
+  }
+  try {
+    await body.dump({ limit: URL_ACCESSIBILITY_BODY_DUMP_LIMIT_BYTES });
+  } catch (error2) {
+    debug(
+      `Unable to drain response body for ${url}: ${errorMessage(error2)}`
+    );
+  }
+};
+async function isUrlAccessible(url, timeout = URL_ACCESSIBILITY_TIMEOUT_MS) {
   const cacheKey = `${url}|${timeout}`;
   const cached = urlAccessibilityCache.get(cacheKey);
   if (cached !== void 0) {
@@ -73878,16 +73905,54 @@ async function isUrlAccessible(url, timeout = 5e3) {
       }
       const safeUrl = new URL(url);
       safeUrl.hostname = ipAddress;
-      const { statusCode } = await (0, import_undici3.request)(safeUrl.toString(), {
-        method: "GET",
-        headers: {
-          Host: parsedUrl.hostname
-        },
-        headersTimeout: timeout,
-        bodyTimeout: timeout
-      });
-      return statusCode === 200;
-    } catch {
+      let lastError;
+      for (let attempt = 1; attempt <= URL_ACCESSIBILITY_ATTEMPTS; attempt++) {
+        try {
+          const { statusCode, body } = await (0, import_undici3.request)(safeUrl.toString(), {
+            method: "GET",
+            headers: {
+              Host: parsedUrl.hostname
+            },
+            headersTimeout: timeout,
+            bodyTimeout: timeout
+          });
+          await drainResponseBody(url, body);
+          if (statusCode === 200) {
+            return true;
+          }
+          lastError = `HTTP ${statusCode}`;
+          if (TRANSIENT_HTTP_STATUSES.has(statusCode)) {
+            if (attempt < URL_ACCESSIBILITY_ATTEMPTS) {
+              debug(
+                `URL accessibility check failed for ${url} on attempt ${attempt}/${URL_ACCESSIBILITY_ATTEMPTS}: ${lastError}`
+              );
+              await sleep(500 * attempt);
+              continue;
+            }
+            break;
+          }
+          debug(
+            `URL accessibility check for ${url} returned HTTP ${statusCode}`
+          );
+          return false;
+        } catch (error2) {
+          lastError = errorMessage(error2);
+        }
+        if (attempt < URL_ACCESSIBILITY_ATTEMPTS) {
+          debug(
+            `URL accessibility check failed for ${url} on attempt ${attempt}/${URL_ACCESSIBILITY_ATTEMPTS}: ${lastError}`
+          );
+          await sleep(500 * attempt);
+        }
+      }
+      warning(
+        `URL accessibility check failed for ${url} after ${URL_ACCESSIBILITY_ATTEMPTS} attempts: ${lastError}`
+      );
+      return false;
+    } catch (error2) {
+      warning(
+        `URL accessibility check failed for ${url}: ${errorMessage(error2)}`
+      );
       return false;
     }
   })();

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import {request} from 'undici'
 import * as dns from 'dns'
 import * as net from 'net'
+import * as core from '@actions/core'
 
 export interface MetadataResult {
   data: Map<string, string | string[]>
@@ -184,15 +185,53 @@ export const isValidDepends = (depends: string): boolean => {
 // This drastically speeds up execution when many cookbooks share the same source_url or issues_url
 const urlAccessibilityCache = new Map<string, Promise<boolean>>()
 
+const URL_ACCESSIBILITY_TIMEOUT_MS = 15000
+const URL_ACCESSIBILITY_ATTEMPTS = 3
+const URL_ACCESSIBILITY_BODY_DUMP_LIMIT_BYTES = 1024 * 1024
+const TRANSIENT_HTTP_STATUSES = new Set([408, 429, 500, 502, 503, 504])
+
+type ResponseBody = {
+  dump?: (opts?: {limit: number; signal?: AbortSignal}) => Promise<void>
+}
+
+const sleep = async (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms))
+
+const errorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    const maybeCode = (error as Error & {code?: string}).code
+    return maybeCode ? `${maybeCode}: ${error.message}` : error.message
+  }
+
+  return String(error)
+}
+
+const drainResponseBody = async (
+  url: string,
+  body: ResponseBody
+): Promise<void> => {
+  if (typeof body.dump !== 'function') {
+    return
+  }
+
+  try {
+    await body.dump({limit: URL_ACCESSIBILITY_BODY_DUMP_LIMIT_BYTES})
+  } catch (error) {
+    core.debug(
+      `Unable to drain response body for ${url}: ${errorMessage(error)}`
+    )
+  }
+}
+
 /**
  * Checks if a URL is accessible (HTTP 200)
  * @param url The URL to check
- * @param timeout The timeout in milliseconds (default: 5000)
+ * @param timeout The timeout in milliseconds (default: 15000)
  * @returns Promise<boolean>
  */
 export async function isUrlAccessible(
   url: string,
-  timeout = 5000
+  timeout = URL_ACCESSIBILITY_TIMEOUT_MS
 ): Promise<boolean> {
   const cacheKey = `${url}|${timeout}`
   const cached = urlAccessibilityCache.get(cacheKey)
@@ -257,16 +296,63 @@ export async function isUrlAccessible(
       const safeUrl = new URL(url)
       safeUrl.hostname = ipAddress
 
-      const {statusCode} = await request(safeUrl.toString(), {
-        method: 'GET',
-        headers: {
-          Host: parsedUrl.hostname
-        },
-        headersTimeout: timeout,
-        bodyTimeout: timeout
-      })
-      return statusCode === 200
-    } catch {
+      let lastError: string | undefined
+
+      for (let attempt = 1; attempt <= URL_ACCESSIBILITY_ATTEMPTS; attempt++) {
+        try {
+          const {statusCode, body} = await request(safeUrl.toString(), {
+            method: 'GET',
+            headers: {
+              Host: parsedUrl.hostname
+            },
+            headersTimeout: timeout,
+            bodyTimeout: timeout
+          })
+
+          await drainResponseBody(url, body)
+
+          if (statusCode === 200) {
+            return true
+          }
+
+          lastError = `HTTP ${statusCode}`
+
+          if (TRANSIENT_HTTP_STATUSES.has(statusCode)) {
+            if (attempt < URL_ACCESSIBILITY_ATTEMPTS) {
+              core.debug(
+                `URL accessibility check failed for ${url} on attempt ${attempt}/${URL_ACCESSIBILITY_ATTEMPTS}: ${lastError}`
+              )
+              await sleep(500 * attempt)
+              continue
+            }
+
+            break
+          }
+
+          core.debug(
+            `URL accessibility check for ${url} returned HTTP ${statusCode}`
+          )
+          return false
+        } catch (error) {
+          lastError = errorMessage(error)
+        }
+
+        if (attempt < URL_ACCESSIBILITY_ATTEMPTS) {
+          core.debug(
+            `URL accessibility check failed for ${url} on attempt ${attempt}/${URL_ACCESSIBILITY_ATTEMPTS}: ${lastError}`
+          )
+          await sleep(500 * attempt)
+        }
+      }
+
+      core.warning(
+        `URL accessibility check failed for ${url} after ${URL_ACCESSIBILITY_ATTEMPTS} attempts: ${lastError}`
+      )
+      return false
+    } catch (error) {
+      core.warning(
+        `URL accessibility check failed for ${url}: ${errorMessage(error)}`
+      )
       return false
     }
   })()

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -1,8 +1,20 @@
 import * as dns from 'dns'
+import * as core from '@actions/core'
 import {request} from 'undici'
 import {isUrlAccessible} from '../src/metadata'
 
 jest.mock('undici')
+jest.mock('@actions/core', () => ({
+  debug: jest.fn(),
+  warning: jest.fn()
+}))
+
+const response = (statusCode: number) => ({
+  statusCode,
+  body: {
+    dump: jest.fn().mockResolvedValue(undefined)
+  }
+})
 
 describe('URL accessibility check', () => {
   beforeEach(() => {
@@ -17,12 +29,14 @@ describe('URL accessibility check', () => {
   })
 
   it('returns true for a reachable URL', async () => {
-    ;(request as jest.Mock).mockResolvedValue({
-      statusCode: 200
-    })
+    const successfulResponse = response(200)
+    ;(request as jest.Mock).mockResolvedValue(successfulResponse)
 
     const result = await isUrlAccessible('https://github.com/sous-chefs/java')
     expect(result).toBe(true)
+    expect(successfulResponse.body.dump).toHaveBeenCalledWith({
+      limit: 1024 * 1024
+    })
     expect(request).toHaveBeenCalledWith(
       expect.stringMatching(/^https:\/\/[0-9.]+\/sous-chefs\/java$/),
       expect.objectContaining({
@@ -30,15 +44,46 @@ describe('URL accessibility check', () => {
         headers: {Host: 'github.com'}
       })
     )
+    expect(request).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headersTimeout: 15000,
+        bodyTimeout: 15000
+      })
+    )
   })
 
   it('returns false for an unreachable URL (404)', async () => {
-    ;(request as jest.Mock).mockResolvedValue({
-      statusCode: 404
-    })
+    ;(request as jest.Mock).mockResolvedValue(response(404))
 
     const result = await isUrlAccessible('https://github.com/non-existent')
     expect(result).toBe(false)
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries transient HTTP statuses before returning success', async () => {
+    ;(request as jest.Mock)
+      .mockResolvedValueOnce(response(503))
+      .mockResolvedValueOnce(response(200))
+
+    const result = await isUrlAccessible(
+      'https://github.com/sous-chefs/transient-status'
+    )
+
+    expect(result).toBe(true)
+    expect(request).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns false after repeated transient HTTP statuses', async () => {
+    ;(request as jest.Mock).mockResolvedValue(response(503))
+
+    const result = await isUrlAccessible(
+      'https://github.com/sous-chefs/persistent-status'
+    )
+
+    expect(result).toBe(false)
+    expect(request).toHaveBeenCalledTimes(3)
+    expect(core.warning).toHaveBeenCalledWith(expect.stringContaining('503'))
   })
 
   it('returns false for a network error', async () => {
@@ -46,6 +91,10 @@ describe('URL accessibility check', () => {
 
     const result = await isUrlAccessible('https://github.com/error')
     expect(result).toBe(false)
+    expect(request).toHaveBeenCalledTimes(3)
+    expect(core.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Network failure')
+    )
   })
 
   it('returns false when request times out', async () => {
@@ -53,6 +102,7 @@ describe('URL accessibility check', () => {
 
     const result = await isUrlAccessible('https://github.com/timeout')
     expect(result).toBe(false)
+    expect(request).toHaveBeenCalledTimes(3)
   })
 
   it('returns false for file:// protocol (SSRF protection)', async () => {
@@ -99,9 +149,7 @@ describe('URL accessibility check', () => {
   })
 
   it('reuses a successful accessibility check for repeated calls', async () => {
-    ;(request as jest.Mock).mockResolvedValue({
-      statusCode: 200
-    })
+    ;(request as jest.Mock).mockResolvedValue(response(200))
 
     const url = 'https://github.com/sous-chefs/shared-success'
 
@@ -114,13 +162,28 @@ describe('URL accessibility check', () => {
   it('does not cache a failed accessibility check', async () => {
     ;(request as jest.Mock)
       .mockRejectedValueOnce(new Error('Transient network failure'))
-      .mockResolvedValueOnce({statusCode: 200})
+      .mockRejectedValueOnce(new Error('Transient network failure'))
+      .mockRejectedValueOnce(new Error('Transient network failure'))
+      .mockResolvedValueOnce(response(200))
 
     const url = 'https://github.com/sous-chefs/retry-after-failure'
 
     await expect(isUrlAccessible(url)).resolves.toBe(false)
     await expect(isUrlAccessible(url)).resolves.toBe(true)
 
+    expect(request).toHaveBeenCalledTimes(4)
+  })
+
+  it('retries transient failures before returning success', async () => {
+    ;(request as jest.Mock)
+      .mockRejectedValueOnce(new Error('Transient network failure'))
+      .mockResolvedValueOnce(response(200))
+
+    const result = await isUrlAccessible(
+      'https://github.com/sous-chefs/transient-success'
+    )
+
+    expect(result).toBe(true)
     expect(request).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Summary
- increase URL accessibility timeout from 5s to 15s
- retry transient request failures up to 3 times with backoff
- log request failure details so future unreachable URL reports are diagnosable
- update URL accessibility tests and rebuild the bundled action dist

## Verification
- npm run all
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/check-chef-metadata-action/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->